### PR TITLE
pass ignore array to the Reporter constructor so that verify function…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,7 +20,7 @@ August 15, 2013 - v0.10.0
 * Update Travis and NPM building (Nick Schonning)
 * Remove Uglify task (Nick Schonning)
 * Add YUITest custom task (Nick Schonning)
-* Add .gitattibutes for line endings (Nick Schonning)
+* Add .gitattributes for line endings (Nick Schonning)
 * Add parser-lib concatination (Nick Schonning)
 * Fix package.json path for Ant (Nick Schonning)
 * Fix linting errors in tests (Nick Schonning)

--- a/lib/yuitest.js
+++ b/lib/yuitest.js
@@ -2683,13 +2683,13 @@ YUITest.Event = (function() {
      * @param {int} detail (Optional) The number of times the mouse button has
      *      been used. The default value is 1.
      * @param {int} screenX (Optional) The x-coordinate on the screen at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} screenY (Optional) The y-coordinate on the screen at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} clientX (Optional) The x-coordinate on the client at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {int} clientY (Optional) The y-coordinate on the client at which
-     *      point the event occured. The default is 0.
+     *      point the event occurred. The default is 0.
      * @param {Boolean} ctrlKey (Optional) Indicates if one of the CTRL keys
      *      is pressed while the event is firing. The default is false.
      * @param {Boolean} altKey (Optional) Indicates if one of the ALT keys

--- a/src/core/CSSLint.js
+++ b/src/core/CSSLint.js
@@ -215,10 +215,10 @@ var CSSLint = (function() {
         if (embeddedRuleset.test(text)) {
             //defensively copy so that caller's version does not get modified
             ruleset = clone(ruleset);
-            ruleset = applyEmbeddedRuleset(text, ruleset, ignore);
+            ruleset = applyEmbeddedRuleset(text, ruleset);
         }
 
-        reporter = new Reporter(lines, ruleset);
+        reporter = new Reporter(lines, ruleset, ignore);
 
         ruleset.errors = 2;       //always report parsing errors as errors
         for (i in ruleset) {

--- a/src/core/Reporter.js
+++ b/src/core/Reporter.js
@@ -7,7 +7,7 @@
  * @param {Object} ruleset The set of rules to work with, including if
  *      they are errors or warnings.
  */
-function Reporter(lines, ruleset) {
+function Reporter(lines, ruleset, ignore) {
     "use strict";
 
     /**
@@ -39,6 +39,16 @@ function Reporter(lines, ruleset) {
      * @type Object
      */
     this.ruleset = ruleset;
+
+    /**
+     * Linesets not to include in the report.
+     * @property ignore
+     * @type [][]
+     */
+    this.ignore = ignore;
+    if(!this.ignore) {
+        this.ignore = [];
+    }
 }
 
 Reporter.prototype = {
@@ -90,6 +100,17 @@ Reporter.prototype = {
      */
     report: function(message, line, col, rule) {
         "use strict";
+
+        var ignore = false;
+        CSSLint.Util.forEach(this.ignore, function (range) {
+            if(range[0] <= line && line <= range[1]) {
+                ignore = true;
+            }
+        });
+        if(ignore) {
+            return;
+        }
+
         this.messages.push({
             type    : this.ruleset[rule.id] === 2 ? "error" : "warning",
             line    : line,

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -5,7 +5,7 @@ CSSLint.Util = {
     /*
      * Adds all properties from supplier onto receiver,
      * overwriting if the same name already exists on
-     * reciever.
+     * receiver.
      * @param {Object} The object to receive the properties.
      * @param {Object} The object to provide the properties.
      * @return {Object} The receiver

--- a/src/formatters/junit-xml.js
+++ b/src/formatters/junit-xml.js
@@ -84,7 +84,7 @@ CSSLint.addFormatter({
                 //ignore rollups for now
                 if (!message.rollup) {
 
-                    // build the test case seperately, once joined
+                    // build the test case separately, once joined
                     // we'll add it to a custom array filtered by type
                     output.push("<testcase time=\"0\" name=\"" + generateSource(message.rule) + "\">");
                     output.push("<" + type + " message=\"" + escapeSpecialCharacters(message.message) + "\"><![CDATA[" + message.line + ":" + message.col + ":" + escapeSpecialCharacters(message.evidence)  + "]]></" + type + ">");

--- a/tests/core/CSSLint.js
+++ b/tests/core/CSSLint.js
@@ -77,6 +77,14 @@
             var report = CSSLint.verify("/* csslint ignore:start */\n/* csslint ignore:start */\n");
             Assert.areEqual(1, report.ignore.length);
             Assert.areEqual(0, report.ignore[0][0]);
+        },
+
+        "Report should not include ignored range": function(){
+            var report = CSSLint.verify(
+              "/* csslint ignore:start */\n .important{ font-size: 14px !important; } \n /* csslint ignore:end */\n" +
+              ".important{ font-size: 14px !important; }"
+            );
+            Assert.areEqual(1, report.messages.length);
         }
 
     }));

--- a/tests/core/CSSLint.js
+++ b/tests/core/CSSLint.js
@@ -48,6 +48,35 @@
             Assert.areEqual(2, result.ruleset["adjoining-classes"]);
             Assert.areEqual(1, result.ruleset["text-indent"]);
             Assert.areEqual(0, result.ruleset["box-sizing"]);
+        },
+
+        "Full ignore blocks should be captured": function(){
+            var report = CSSLint.verify("/* csslint ignore:start */\n\n/* csslint ignore:end */");
+            Assert.areEqual(1, report.ignore.length);
+            Assert.areEqual(0, report.ignore[0][0]);
+            Assert.areEqual(2, report.ignore[0][1]);
+        },
+
+        "Whitespace should be no problem inside ignore comments": function(){
+            var report = CSSLint.verify("/*     csslint     ignore:start    */\n\n/*    csslint     ignore:end     */,\n/*csslint ignore:start*/\n/*csslint ignore:end*/");
+            Assert.areEqual(2, report.ignore.length);
+            Assert.areEqual(0, report.ignore[0][0]);
+            Assert.areEqual(2, report.ignore[0][1]);
+            Assert.areEqual(3, report.ignore[1][0]);
+            Assert.areEqual(4, report.ignore[1][1]);
+        },
+
+        "Ignore blocks should be autoclosed": function(){
+            var report = CSSLint.verify("/* csslint ignore:start */\n\n");
+            Assert.areEqual(1, report.ignore.length);
+            Assert.areEqual(0, report.ignore[0][0]);
+            Assert.areEqual(3, report.ignore[0][1]);
+        },
+
+        "Restarting ignore should be harmless": function(){
+            var report = CSSLint.verify("/* csslint ignore:start */\n/* csslint ignore:start */\n");
+            Assert.areEqual(1, report.ignore.length);
+            Assert.areEqual(0, report.ignore[0][0]);
         }
 
     }));

--- a/tests/core/Reporter.js
+++ b/tests/core/Reporter.js
@@ -28,6 +28,14 @@
 
             Assert.areEqual(1, reporter.messages.length);
             Assert.areEqual("error", reporter.messages[0].type);
+        },
+
+        "Ignores should step over a report in their range": function(){
+            var reporter = new CSSLint._Reporter([], { "fake-rule": 1}, [[1,3]]);
+            reporter.report("Foo", 2, 1, { id: "fake-rule" });
+            reporter.report("Bar", 5, 1, { id: "fake-rule" });
+
+            Assert.areEqual(1, reporter.messages.length);
         }
 
     }));


### PR DESCRIPTION
… ignores correctly

added related test

I have been hoping your PR to csslint would get merged but I noticed it wasn't working for me in practice. I made this PR to illustrate the problem.

Without this change, if I create a css file with the csslint ignore:start/end and run it through the command line tool, it doesn't ignore.